### PR TITLE
fix: skip checksum if checksums file not found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+        version:
+          - latest
+          - 0.32.1
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install missing dependencies
@@ -24,3 +28,4 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v3
         with:
           command: vector --help
+          version: ${{ matrix.version }}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ install & manage versions.
 # Environment Variables
 
 - `ASDF_VECTOR_DISABLE_ROSETTA`: Set to any non-empty value to disable defaulting back to using Rosetta 2 on Apple Silicon Macs if a native version is not available. This is useful if you do not want to install binaries that require Rosetta 2 to run.
+- `ASDF_VECTOR_FORCE_CHECKSUM`: Set to any non-empty value to fail if there are no tools to verify the checksum of the downloaded archive, or if the file containing the checksums is not found. By default, this is a best effort process.
 
 # Contributing
 


### PR DESCRIPTION
Realized that on older versions (e.g. 0.32.1) there is no checksums file, which makes things fail.